### PR TITLE
Provide a mapping that preserves tags and digests

### DIFF
--- a/pkg/pathmapping/ginkgo_suite_test.go
+++ b/pkg/pathmapping/ginkgo_suite_test.go
@@ -25,5 +25,5 @@ import (
 
 func TestCommands(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Core Suite")
+	RunSpecs(t, "Path Mapping Suite")
 }

--- a/pkg/pathmapping/path_mapping_test.go
+++ b/pkg/pathmapping/path_mapping_test.go
@@ -14,162 +14,156 @@
  * limitations under the License.
  */
 
-package pathmapping
+package pathmapping_test
 
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/pathmapping"
 )
 
-var _ = Describe("Path Mapping", func() {
+var _ = Describe("FlattenRepoPath", func() {
 	var (
-		mapper PathMapping
 		name   image.Name
 		mapped string
 	)
 
 	JustBeforeEach(func() {
-		mapped = mapper("test.host/testuser", name).String()
+		mapped = pathmapping.FlattenRepoPath("test.host/testuser", name).String()
 
 		// check that the mapped path is valid
 		_, err := image.NewName(mapped)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	Context("when flattening is performed", func() {
+	Context("when the image path has a single element", func() {
 		BeforeEach(func() {
-			mapper = FlattenRepoPath
+			var err error
+			name, err = image.NewName("some.registry.com/some-user")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path has a single element", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should flatten the path correctly", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-9482d6a53a1789fb7304a4fe88362903"))
+		})
+	})
 
-			It("should flatten the path correctly", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-9482d6a53a1789fb7304a4fe88362903"))
-			})
+	Context("when the image path has more than a single element", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some/path")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path has more than a single element", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/some/path")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should flatten the path correctly", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
+		})
+	})
 
-			It("should flatten the path correctly", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
-			})
+	Context("when the image has a tag", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some/path:v1")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image has a tag", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/some/path:v1")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should flatten the path correctly", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
+		})
+	})
 
-			It("should flatten the path correctly", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
-			})
+	Context("when the image has a digest", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some/path@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image has a digest", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/some/path@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should flatten the path correctly", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
+		})
+	})
 
-			It("should flatten the path correctly", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
-			})
+	Context("when the image has a digest and a tag", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some/path:v1@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image has a digest and a tag", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/some/path:v1@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should flatten the path correctly", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
+		})
+	})
 
-			It("should flatten the path correctly", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-some-path-3236c106420c1d0898246e1d2b6ba8b6"))
-			})
+	Context("when the image path is long and has many elements", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/axxxxxxxxx/bxxxxxxxxx/cxxxxxxxxx/dxxxxxxxxx/" +
+				"exxxxxxxxx/fxxxxxxxxx/gxxxxxxxxx/hxxxxxxxxx/ixxxxxxxxx/jxxxxxxxxx/kxxxxxxxxx/lxxxxxxxxx/" +
+				"mxxxxxxxxx/nxxxxxxxxx/oxxxxxxxxx/pxxxxxxxxx/qxxxxxxxxx/rxxxxxxxxx/sxxxxxxxxx/txxxxxxxxx")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path is long and has many elements", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/axxxxxxxxx/bxxxxxxxxx/cxxxxxxxxx/dxxxxxxxxx/" +
-					"exxxxxxxxx/fxxxxxxxxx/gxxxxxxxxx/hxxxxxxxxx/ixxxxxxxxx/jxxxxxxxxx/kxxxxxxxxx/lxxxxxxxxx/" +
-					"mxxxxxxxxx/nxxxxxxxxx/oxxxxxxxxx/pxxxxxxxxx/qxxxxxxxxx/rxxxxxxxxx/sxxxxxxxxx/txxxxxxxxx")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should omit some portions of the path", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-axxxxxxxxx-bxxxxxxxxx-cxxxxxxxxx-dxxxxxxxxx-exxxxxxxxx-fxxxxxxxxx-gxxxxxxxxx-hxxxxxxxxx-ixxxxxxxxx-jxxxxxxxxx-kxxxxxxxxx-lxxxxxxxxx-mxxxxxxxxx-nxxxxxxxxx-oxxxxxxxxx-pxxxxxxxxx---txxxxxxxxx-b0d16e8b4d43f2ec842cfcc61989a966"))
+		})
+	})
 
-			It("should omit some portions of the path", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-axxxxxxxxx-bxxxxxxxxx-cxxxxxxxxx-dxxxxxxxxx-exxxxxxxxx-fxxxxxxxxx-gxxxxxxxxx-hxxxxxxxxx-ixxxxxxxxx-jxxxxxxxxx-kxxxxxxxxx-lxxxxxxxxx-mxxxxxxxxx-nxxxxxxxxx-oxxxxxxxxx-pxxxxxxxxx---txxxxxxxxx-b0d16e8b4d43f2ec842cfcc61989a966"))
-			})
+	Context("when the image path is long and has few elements", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
+				"exxxxxxxxxefxxxxxxxxx/gxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
+				"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxx/txxxxxxxxx")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path is long and has few elements", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
-					"exxxxxxxxxefxxxxxxxxx/gxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
-					"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxx/txxxxxxxxx")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should omit some portions of the path", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxdexxxxxxxxxefxxxxxxxxx---txxxxxxxxx-4817a2fce97ff7aae687d14e66328781"))
+		})
+	})
 
-			It("should omit some portions of the path", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxdexxxxxxxxxefxxxxxxxxx---txxxxxxxxx-4817a2fce97ff7aae687d14e66328781"))
-			})
+	Context("when the image path is long and has two elements", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
+				"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
+				"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxxstxxxxxxxxx")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path is long and has two elements", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
-					"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
-					"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxxstxxxxxxxxx")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should omit some portions of the path", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user-a363dc80420c33618202ba2828aec456"))
+		})
+	})
 
-			It("should omit some portions of the path", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user-a363dc80420c33618202ba2828aec456"))
-			})
+	Context("when the image path is long and has three elements", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
+				"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
+				"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxx/txxxxxxxxx")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the image path is long and has three elements", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/some-user/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
-					"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
-					"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxx/txxxxxxxxx")
-				Expect(err).NotTo(HaveOccurred())
-			})
+		It("should omit some portions of the path", func() {
+			Expect(mapped).To(Equal("test.host/testuser/some-user---txxxxxxxxx-5134b4594954926468fe0bdc23f640ef"))
+		})
+	})
 
-			It("should omit some portions of the path", func() {
-				Expect(mapped).To(Equal("test.host/testuser/some-user---txxxxxxxxx-5134b4594954926468fe0bdc23f640ef"))
-			})
+	Context("when the first element of the image path is long", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
+				"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
+				"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxxstxxxxxxxxx/suffix")
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		Context("when the first element of the image path is long", func() {
-			BeforeEach(func() {
-				var err error
-				name, err = image.NewName("some.registry.com/axxxxxxxxxabxxxxxxxxxbcxxxxxxxxxcdxxxxxxxxxd" +
-					"exxxxxxxxxefxxxxxxxxxfgxxxxxxxxxghxxxxxxxxxhixxxxxxxxxijxxxxxxxxxjkxxxxxxxxxklxxxxxxxxxl" +
-					"mxxxxxxxxxmnxxxxxxxxxnoxxxxxxxxxopxxxxxxxxxpqxxxxxxxxxqrxxxxxxxxxrsxxxxxxxxxstxxxxxxxxx/suffix")
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			It("should omit some portions of the path", func() {
-				Expect(mapped).To(Equal("test.host/testuser/suffix-3fa7b8289050d7d4fe5d56f3098397a0"))
-			})
+		It("should omit some portions of the path", func() {
+			Expect(mapped).To(Equal("test.host/testuser/suffix-3fa7b8289050d7d4fe5d56f3098397a0"))
 		})
 	})
 })

--- a/pkg/pathmapping/tag_digest_mapping.go
+++ b/pkg/pathmapping/tag_digest_mapping.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathmapping
+
+import (
+	"github.com/pivotal/image-relocation/pkg/image"
+)
+
+// FlattenRepoPathPreserveTagDigest maps the given Name to a new Name with a given repository prefix.
+// It aims to avoid collisions between repositories and to include enough of the original name
+// to make it recognizable by a human being. It preserves any tag and/or digest.
+func FlattenRepoPathPreserveTagDigest(repoPrefix string, originalImage image.Name) image.Name {
+	rn := FlattenRepoPath(repoPrefix, originalImage)
+
+	// Preserve any tag
+	if tag := originalImage.Tag(); tag != "" {
+		var err error
+		rn, err = rn.WithTag(tag)
+		if err != nil {
+			panic(err) // should never occur
+		}
+	}
+
+	// Preserve any digest
+	if dig := originalImage.Digest(); dig != image.EmptyDigest {
+		var err error
+		rn, err = rn.WithDigest(dig)
+		if err != nil {
+			panic(err) // should never occur
+		}
+	}
+
+	return rn
+}

--- a/pkg/pathmapping/tag_digest_mapping_test.go
+++ b/pkg/pathmapping/tag_digest_mapping_test.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2019-Present Pivotal Software, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathmapping_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal/image-relocation/pkg/image"
+	"github.com/pivotal/image-relocation/pkg/pathmapping"
+)
+
+var _ = Describe("FlattenRepoPathPreserveTagDigest", func() {
+
+	const expectedMappedPath = "test.host/testuser/some-user-some-path-f4cdc2223f0c472921033d606fa74a89"
+
+	var (
+		name   image.Name
+		mapped string
+		mappedWithoutTagOrDigest string
+		tag string
+		digest string
+	)
+
+	JustBeforeEach(func() {
+		result := pathmapping.FlattenRepoPathPreserveTagDigest("test.host/testuser", name)
+		mapped = result.String()
+		tag = result.Tag()
+		digest = result.Digest().String()
+		mappedWithoutTagOrDigest = result.WithoutTagOrDigest().String()
+
+		// check that the mapped path is valid
+		_, err := image.NewName(mapped)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when the image has neither a tag nor a digest", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some-path")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should map the image correctly", func() {
+			Expect(mapped).To(Equal(expectedMappedPath))
+		})
+
+		It("should not introduce a tag", func() {
+		    Expect(tag).To(BeEmpty())
+		})
+
+		It("should not introduce a digest", func() {
+		    Expect(digest).To(BeEmpty())
+		})
+	})
+
+	Context("when the image has a tag", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some-path:v1")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should preserve the tag", func() {
+			Expect(tag).To(Equal("v1"))
+		})
+
+		It("should not introduce a digest", func() {
+			Expect(digest).To(BeEmpty())
+		})
+
+		It("should map the path without regard to the tag", func() {
+			Expect(mappedWithoutTagOrDigest).To(Equal(expectedMappedPath))
+		})
+	})
+
+	Context("when the image has a digest", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some-path@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not introduce a tag", func() {
+			Expect(tag).To(BeEmpty())
+		})
+
+		It("should preserve the digest", func() {
+			Expect(digest).To(Equal("sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870"))
+		})
+
+		It("should map the path without regard to the digest", func() {
+			Expect(mappedWithoutTagOrDigest).To(Equal(expectedMappedPath))
+		})
+	})
+
+	Context("when the image has a digest and a tag", func() {
+		BeforeEach(func() {
+			var err error
+			name, err = image.NewName("some.registry.com/some-user/some-path:v1@sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should preserve the tag", func() {
+			Expect(tag).To(Equal("v1"))
+		})
+
+		It("should preserve the digest", func() {
+			Expect(digest).To(Equal("sha256:1e725169f37aec55908694840bc808fb13ebf02cb1765df225437c56a796f870"))
+		})
+
+		It("should map the path without regard to the tag or the digest", func() {
+			Expect(mappedWithoutTagOrDigest).To(Equal(expectedMappedPath))
+		})
+	})
+})


### PR DESCRIPTION
Note: code coverage is made worse by this change because of some defensive coding.

Fixes https://github.com/pivotal/image-relocation/issues/4