### PR TITLE
Preserve tag when writing to a tagged and digested image reference

### DIFF
--- a/pkg/irel/layout_add.go
+++ b/pkg/irel/layout_add.go
@@ -18,10 +18,11 @@ package irel
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/registry/ggcr"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 func newCmdLayoutAdd() *cobra.Command {
@@ -41,7 +42,7 @@ func layoutAdd(cmd *cobra.Command, args []string) {
 	}
 
 	regClient := ggcr.NewRegistryClient()
-	layout, err := regClient.NewLayout(layoutPath)
+	layout, err := regClient.ReadLayout(layoutPath)
 	if err != nil {
 		layout, err = regClient.NewLayout(layoutPath)
 		if err != nil {

--- a/pkg/registry/ggcr/remote.go
+++ b/pkg/registry/ggcr/remote.go
@@ -86,7 +86,7 @@ func writeRemoteImage(i v1.Image, n image.Name) error {
 		return err
 	}
 
-	ref, err := name.ParseReference(n.String(), name.WeakValidation)
+	ref, err := getWriteReference(n)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func writeRemoteIndex(i v1.ImageIndex, n image.Name) error {
 		return err
 	}
 
-	ref, err := name.ParseReference(n.String(), name.WeakValidation)
+	ref, err := getWriteReference(n)
 	if err != nil {
 		return err
 	}
@@ -118,4 +118,14 @@ func resolve(n image.Name) (authn.Authenticator, error) {
 	}
 
 	return resolveFunc(repo.Registry)
+}
+
+func getWriteReference(n image.Name) (name.Reference, error) {
+	// if target image reference is both tagged and digested, ignore the digest so the tag is preserved
+	// (the digest will be preserved by go-containerregistry)
+	if n.Tag() != "" {
+		n = n.WithoutDigest()
+	}
+
+	return name.ParseReference(n.String(), name.WeakValidation)
 }

--- a/pkg/registry/ggcr/remote_test.go
+++ b/pkg/registry/ggcr/remote_test.go
@@ -2,6 +2,7 @@ package ggcr
 
 import (
 	"errors"
+	"fmt"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -16,8 +17,9 @@ var _ = Describe("remote utilities", func() {
 	var (
 		imageName image.Name
 		mockImage *ggcrfakes.FakeImage
-		testError error
-		err       error
+		testDigest string
+	testError error
+	err       error
 	)
 
 	BeforeEach(func() {
@@ -25,8 +27,9 @@ var _ = Describe("remote utilities", func() {
 		imageName, err = image.NewName("imagename")
 		Expect(err).NotTo(HaveOccurred())
 
+		testDigest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 		mockImage = &ggcrfakes.FakeImage{}
-		h1, err := v1.NewHash("sha256:0000000000000000000000000000000000000000000000000000000000000000")
+		h1, err := v1.NewHash(testDigest)
 		Expect(err).NotTo(HaveOccurred())
 		mockImage.DigestReturns(h1, nil)
 
@@ -110,6 +113,84 @@ var _ = Describe("remote utilities", func() {
 
 			It("should return an error", func() {
 				Expect(err).To(MatchError("empty image name invalid"))
+			})
+		})
+
+		Context("when the image name is both tagged and digested", func() {
+			var writeRef name.Reference
+			BeforeEach(func() {
+				imageName, err = image.NewName(fmt.Sprintf("example.com/eg:1@%s", testDigest))
+				Expect(err).NotTo(HaveOccurred())
+				repoWriteFunc = func(ref name.Reference, img v1.Image, options ...remote.Option) error {
+					writeRef = ref
+					return nil
+				}
+			})
+
+			It("should discard the digest from the written reference", func() {
+				Expect(writeRef.String()).To(Equal("example.com/eg:1"))
+			})
+		})
+	})
+
+	Describe("writeRemoteIndex", func() {
+		var mockIndex *ggcrfakes.FakeImageIndex
+
+		BeforeEach(func() {
+			mockIndex = &ggcrfakes.FakeImageIndex{}
+		})
+
+		JustBeforeEach(func() {
+			err = writeRemoteIndex(mockIndex, imageName)
+		})
+
+		Context("when writing to the repository succeeds", func() {
+			BeforeEach(func() {
+				repoIndexWriteFunc = func(ref name.Reference, ii v1.ImageIndex, options ...remote.Option) error {
+					return nil
+				}
+			})
+
+			It("should succeed", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when writing to the repository return an error", func() {
+			BeforeEach(func() {
+				repoIndexWriteFunc = func(ref name.Reference, ii v1.ImageIndex, options ...remote.Option) error {
+					return testError
+				}
+			})
+
+			It("should return the error", func() {
+				Expect(err).To(Equal(testError))
+			})
+		})
+
+		Context("when the image name is empty", func() {
+			BeforeEach(func() {
+				imageName = image.EmptyName
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(MatchError("empty image name invalid"))
+			})
+		})
+
+		Context("when the image name is both tagged and digested", func() {
+			var writeRef name.Reference
+			BeforeEach(func() {
+				imageName, err = image.NewName(fmt.Sprintf("example.com/eg:1@%s", testDigest))
+				Expect(err).NotTo(HaveOccurred())
+				repoIndexWriteFunc = func(ref name.Reference, ii v1.ImageIndex, options ...remote.Option) error {
+					writeRef = ref
+					return nil
+				}
+			})
+
+			It("should discard the digest from the written reference", func() {
+				Expect(writeRef.String()).To(Equal("example.com/eg:1"))
 			})
 		})
 	})


### PR DESCRIPTION
Ignore the digest, which is preserved anyway.

Fixes https://github.com/pivotal/image-relocation/issues/33