### PR TITLE
Return error instead of panicking

### DIFF
--- a/pkg/irel/env.go
+++ b/pkg/irel/env.go
@@ -24,6 +24,7 @@ var (
 	cli_gitdirty = ""
 )
 
+// CliVersion returns a version string based on values supplied at build time
 func CliVersion() string {
 	var version string
 	if cli_gitdirty == "" {

--- a/pkg/irel/map.go
+++ b/pkg/irel/map.go
@@ -18,10 +18,11 @@ package irel
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/pivotal/image-relocation/pkg/image"
 	"github.com/pivotal/image-relocation/pkg/pathmapping"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 func init() { Root.AddCommand(newCmdMap()) }
@@ -49,5 +50,9 @@ func pathMapping(repoPrefix string, args []string) {
 		log.Fatalf("invalid reference %q: %v", refStr, err)
 	}
 
-	fmt.Printf("%s\n", pathmapping.FlattenRepoPathPreserveTagDigest(repoPrefix, ref))
+	mapped, err := pathmapping.FlattenRepoPathPreserveTagDigest(repoPrefix, ref)
+	if err != nil {
+		log.Fatalf("path flattening failed: %v", err)
+	}
+	fmt.Printf("%s\n", mapped)
 }

--- a/pkg/irel/root.go
+++ b/pkg/irel/root.go
@@ -30,6 +30,7 @@ var (
 	caCertPaths   []string
 	skipTLSVerify bool
 
+	// Root is the root of the tree of irel commands
 	Root = &cobra.Command{
 		Use:               "irel",
 		Short:             "irel is a tool for relocating container images",
@@ -51,4 +52,3 @@ func mustGetRegistryClient() registry.Client {
 
 	return ggcr.NewRegistryClient(ggcr.WithTransport(tport))
 }
-

--- a/pkg/pathmapping/path_mapping.go
+++ b/pkg/pathmapping/path_mapping.go
@@ -28,12 +28,12 @@ import (
 )
 
 // PathMapping is a type of function which maps a given Name to a new Name by apply a repository prefix.
-type PathMapping func(repoPrefix string, originalImage image.Name) image.Name
+type PathMapping func(repoPrefix string, originalImage image.Name) (image.Name, error)
 
 // FlattenRepoPath maps the given Name to a new Name with a given repository prefix.
 // It aims to avoid collisions between repositories and to include enough of the original name
 // to make it recognizable by a human being.
-func FlattenRepoPath(repoPrefix string, originalImage image.Name) image.Name {
+func FlattenRepoPath(repoPrefix string, originalImage image.Name) (image.Name, error) {
 	hasher := md5.New()
 	hasher.Write([]byte(originalImage.Name()))
 	hash := hex.EncodeToString(hasher.Sum(nil))
@@ -47,9 +47,9 @@ func FlattenRepoPath(repoPrefix string, originalImage image.Name) image.Name {
 	}
 	mn, err := image.NewName(mp)
 	if err != nil {
-		panic(err) // should not happen
+		return image.EmptyName, err // should never occur
 	}
-	return mn
+	return mn, nil
 }
 
 func mappedPath(repoPrefix string, repoPath string, hash string) string {

--- a/pkg/pathmapping/path_mapping_test.go
+++ b/pkg/pathmapping/path_mapping_test.go
@@ -30,10 +30,12 @@ var _ = Describe("FlattenRepoPath", func() {
 	)
 
 	JustBeforeEach(func() {
-		mapped = pathmapping.FlattenRepoPath("test.host/testuser", name).String()
+		mappedImage, err := pathmapping.FlattenRepoPath("test.host/testuser", name)
+		Expect(err).NotTo(HaveOccurred())
+		mapped = mappedImage.String()
 
 		// check that the mapped path is valid
-		_, err := image.NewName(mapped)
+		_, err = image.NewName(mapped)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/pkg/pathmapping/tag_digest_mapping.go
+++ b/pkg/pathmapping/tag_digest_mapping.go
@@ -23,15 +23,18 @@ import (
 // FlattenRepoPathPreserveTagDigest maps the given Name to a new Name with a given repository prefix.
 // It aims to avoid collisions between repositories and to include enough of the original name
 // to make it recognizable by a human being. It preserves any tag and/or digest.
-func FlattenRepoPathPreserveTagDigest(repoPrefix string, originalImage image.Name) image.Name {
-	rn := FlattenRepoPath(repoPrefix, originalImage)
+func FlattenRepoPathPreserveTagDigest(repoPrefix string, originalImage image.Name) (image.Name, error) {
+	rn, err := FlattenRepoPath(repoPrefix, originalImage)
+	if err != nil {
+		return image.EmptyName, err
+	}
 
 	// Preserve any tag
 	if tag := originalImage.Tag(); tag != "" {
 		var err error
 		rn, err = rn.WithTag(tag)
 		if err != nil {
-			panic(err) // should never occur
+			return image.EmptyName, err // should never occur
 		}
 	}
 
@@ -40,9 +43,9 @@ func FlattenRepoPathPreserveTagDigest(repoPrefix string, originalImage image.Nam
 		var err error
 		rn, err = rn.WithDigest(dig)
 		if err != nil {
-			panic(err) // should never occur
+			return image.EmptyName, err // should never occur
 		}
 	}
 
-	return rn
+	return rn, nil
 }

--- a/pkg/pathmapping/tag_digest_mapping_test.go
+++ b/pkg/pathmapping/tag_digest_mapping_test.go
@@ -28,22 +28,23 @@ var _ = Describe("FlattenRepoPathPreserveTagDigest", func() {
 	const expectedMappedPath = "test.host/testuser/some-user-some-path-f4cdc2223f0c472921033d606fa74a89"
 
 	var (
-		name   image.Name
-		mapped string
+		name                     image.Name
+		mapped                   string
 		mappedWithoutTagOrDigest string
-		tag string
-		digest string
+		tag                      string
+		digest                   string
 	)
 
 	JustBeforeEach(func() {
-		result := pathmapping.FlattenRepoPathPreserveTagDigest("test.host/testuser", name)
+		result, err := pathmapping.FlattenRepoPathPreserveTagDigest("test.host/testuser", name)
+		Expect(err).NotTo(HaveOccurred())
 		mapped = result.String()
 		tag = result.Tag()
 		digest = result.Digest().String()
 		mappedWithoutTagOrDigest = result.WithoutTagOrDigest().String()
 
 		// check that the mapped path is valid
-		_, err := image.NewName(mapped)
+		_, err = image.NewName(mapped)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -59,11 +60,11 @@ var _ = Describe("FlattenRepoPathPreserveTagDigest", func() {
 		})
 
 		It("should not introduce a tag", func() {
-		    Expect(tag).To(BeEmpty())
+			Expect(tag).To(BeEmpty())
 		})
 
 		It("should not introduce a digest", func() {
-		    Expect(digest).To(BeEmpty())
+			Expect(digest).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
Although these panics should never occur, they make downstream consumers
nervous and have led to users forking the code. So the code now returns an
error which should never be non-nil and it is up to the caller to handle it
appropriately.

Also fix a few lint and formatting issues.